### PR TITLE
read version from `git describe`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,24 @@
-import setuptools
-from os.path import splitext,basename
+import subprocess
 from glob import glob
+from os.path import splitext, basename
+
+import setuptools
+
+
+def get_gitlabel():
+    git = subprocess.run(['git', 'describe', '--always'], capture_output=True)
+    gitlabel = git.stdout.decode().strip()
+    if gitlabel.startswith('v'):
+        gitlabel = gitlabel[1:]
+    return gitlabel
+
 
 with open("README.md") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="hello-flask-world",
-    version="0.0.1",
+    version=get_gitlabel(),
     author="Terrel Shumway",
     author_email="ghdev@learnflask.dev",
     description="Boilerplate project for a simple Flask app",
@@ -25,7 +36,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     entry_points={
-        'console_scripts':[
+        'console_scripts': [
             "helloflask=helloflask.cli:main"
         ]
     }


### PR DESCRIPTION
This is a simple fix for #2.

It works for our process (packaging from a git working copy) but would fail if (for example) someone tried to build from a sdist package. *Don't do that*.